### PR TITLE
Typo fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
+.venv/*
 venv/*
 .vscode/*
 *.pyc
+*.session
+logs.txt
 config.env

--- a/TelegramBot/database/MongoDb.py
+++ b/TelegramBot/database/MongoDb.py
@@ -1,6 +1,6 @@
 import sys
 from typing import Union
-from motor.motor_asyncio import AsyncIOMotorClient
+from pymongo import AsyncMongoClient
 
 from TelegramBot.logging import LOGGER
 from TelegramBot.config import MONGO_URI
@@ -89,7 +89,7 @@ class MongoDB:
 
 async def check_mongo_uri(MONGO_URI: str) -> None:
     try:
-        mongo = AsyncIOMotorClient(MONGO_URI)
+        mongo = AsyncMongoClient(MONGO_URI)
         await mongo.server_info()
     except:
         LOGGER(__name__).error(
@@ -99,7 +99,7 @@ async def check_mongo_uri(MONGO_URI: str) -> None:
 
 
 # Initiating MongoDb motor client
-mongodb = AsyncIOMotorClient(MONGO_URI)
+mongodb = AsyncMongoClient(MONGO_URI)
 
 # Database Name (TelegramBot).
 database = mongodb.TelegramBot

--- a/TelegramBot/plugins/sudo/dbstats.py
+++ b/TelegramBot/plugins/sudo/dbstats.py
@@ -13,8 +13,8 @@ async def dbstats(_, message: Message):
     of bot user and total number of bot chats.
     """
 
-    TotalUsers = await mongodb.users.total_documents()
-    TotalChats = await mongodb.chats.total_documents()
+    TotalUsers = await MongoDb.users.total_documents()
+    TotalChats = await MongoDb.chats.total_documents()
 
     stats_string = f"**Bot Database Statics.\n\n**Total Number of users = {TotalUsers}\nTotal number of chats  = {TotalChats}"
     return await message.reply_text(stats_string)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pyrate-limiter==2.10.0
-Pyrogram>=2.0.59
-TgCrypto==1.2.4
+pyrofork
+tgcrypto-pyrofork
 python-dotenv 
 speedtest-cli
 telegraph[aio]
@@ -8,7 +8,7 @@ cachetools
 aiofiles
 psutil
 httpx
-motor
+pymongo
 bs4
 uvloop
 pillow


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the typo in the dbstats plugin by replacing 'mongodb' with 'MongoDb' for user and chat document counting